### PR TITLE
aarch64: fix MRS/MSR in writeELR_EL1

### DIFF
--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -300,7 +300,7 @@ static inline word_t readELR_EL1(void)
 
 static inline void writeELR_EL1(word_t reg)
 {
-    MRS(REG_ELR_EL1, reg);
+    MSR(REG_ELR_EL1, reg);
 }
 
 static inline word_t readSPSR_EL1(void)


### PR DESCRIPTION
Fixes a bug where writeELR_EL1 was reading from ELR_EL1 instead of
writing to it.