### PR TITLE
update non-mcs sabre clock

### DIFF
--- a/src/plat/imx6/config.cmake
+++ b/src/plat/imx6/config.cmake
@@ -43,7 +43,7 @@ if(KernelPlatImx6)
         set(timer_freq 498000000llu)
     else()
         set(timer_file drivers/timer/arm_priv.h)
-        set(timer_freq 400000000llu)
+        set(timer_freq 498000000llu)
     endif()
 
     declare_default_headers(


### PR DESCRIPTION
Both the private and global arm timers are clocked from the same source
and neither of the drivers apply a pre-scaler so the frequency should be
the same in both configurations.

The frequency of this clock is based on PLL1 which could potentially lie
anywhere in the range of 650MHz to 1.3GHz. The value determined for MCS
appears to correctly agree with the user-level timer which appears to be
correctly implemented.