### PR TITLE
mcs: allow replyGrant for fault handlers

### DIFF
--- a/src/kernel/faulthandler.c
+++ b/src/kernel/faulthandler.c
@@ -31,7 +31,8 @@ bool_t sendFaultIPC(tcb_t *tptr, cap_t handlerCap, bool_t can_donate)
 {
     if (cap_get_capType(handlerCap) == cap_endpoint_cap) {
         assert(cap_endpoint_cap_get_capCanSend(handlerCap));
-        assert(cap_endpoint_cap_get_capCanGrant(handlerCap));
+        assert(cap_endpoint_cap_get_capCanGrant(handlerCap) ||
+               cap_endpoint_cap_get_capCanGrantReply(handlerCap));
 
         tptr->tcbFault = current_fault;
         sendIPC(true, false,

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1008,7 +1008,8 @@ static bool_t validFaultHandler(cap_t cap)
     switch (cap_get_capType(cap)) {
     case cap_endpoint_cap:
         if (!cap_endpoint_cap_get_capCanSend(cap) ||
-            !cap_endpoint_cap_get_capCanGrant(cap)) {
+            (!cap_endpoint_cap_get_capCanGrant(cap) &&
+             !cap_endpoint_cap_get_capCanGrantReply(cap))) {
             current_syscall_error.type = seL4_InvalidCapability;
             return false;
         }


### PR DESCRIPTION
The MCS kernel so far insisted on full grant rights for fault handler
caps, but replyGrant is sufficient and consistent with the default
kernel config.