### PR TITLE
riscv,interrupt: Allow checkIRQ to use full range

### DIFF
--- a/src/arch/riscv/object/interrupt.c
+++ b/src/arch/riscv/object/interrupt.c
@@ -12,7 +12,7 @@
 
 exception_t Arch_checkIRQ(word_t irq)
 {
-    if (irq > PLIC_MAX_IRQ || irq == irqInvalid) {
+    if (irq > maxIRQ || irq == irqInvalid) {
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = 1;
         current_syscall_error.rangeErrorMax = maxIRQ;


### PR DESCRIPTION
Any IRQs in the 0,maxIRQ range will be reserved by the kernel already if
userlevel is unable to access them.